### PR TITLE
Adding usage example code for new SHMEM teams routine

### DIFF
--- a/teams/usage/README.md
+++ b/teams/usage/README.md
@@ -1,0 +1,31 @@
+# Test Details
+
+---
+
+Tests in this directory are example programs, and there is no
+verification performed on the end of each tests. These example
+programs are just used to show the users on the actual usage of
+the new team creation, destroy, team-based reduction routines.
+
+# Build Instructions
+
+---
+
+Each program can be compiled separately without adding any extra
+flags. We should make sure that the new SHMEM team routines are
+supported by the implementation. Team routines used in this 
+directory are available in Cray SHMEM from version 7.5.0
+```
+cc shmemx-team-sum-to-all.c -o sma
+```
+
+# Running Tests
+
+---
+
+There is no need for any special flags to run these routines. On 
+ALPS-based Cray system. We can run the tests as shown below:
+```
+aprun -n 4 -N 2 ./sma
+```
+

--- a/teams/usage/shmemx-team-and-to-all.c
+++ b/teams/usage/shmemx-team-and-to-all.c
@@ -1,0 +1,131 @@
+/*
+ * Example program to show the usage of shmemx_team_<datatype>_and_to_all
+ * routine
+ *
+ * SYNOPSIS:
+ * void shmemx_team_<datatype>_and_to_all(    shmem_team_t team,
+ *                                              <datatype>  *dest,
+ *                                              <datatype>  *source,
+ *                                              int          nreduce,
+ *                                              <datatype>  *pWrk,
+ *                                              long        *pSync  )
+ * 
+ * where <datatype> is one from short, int, long, and longlong
+ *
+ * DESCRIPTION:
+ * The shmemx_team_<datatype>_and_to_all is a collective routine which 
+ * compute one or more reductions across symmetric arrays on multiple 
+ * virtual PEs. A reduction performs an associative binary operation across
+ * a set of values. Each of these routines asandes that only PEs which are
+ * members of the team call the routine. If a PE not a member of the team
+ * calls a collective reduction routine, undefined behaviour results.
+ *
+ * The nreduce argument determines the number of separate reductions to
+ * perform. The source array on all PEs in the team provides one 
+ * element for each reduction. The results of the reductions are placed
+ * in the target array on all PEs in the team. The team is determined using 
+ * the team handle provided as input.
+ *
+ * The source and target arrays may be the same array, but they may not be 
+ * overlapping arrays.
+ *
+ * The shmemx_team_<datatype>_and_to_all supports the following options:
+ * team     
+ *              A valid PE team. A predefined team constant or any team 
+ *              created by a split team routine may be used
+ *
+ * dest
+ *              A symmetric array of length nreduce elements to receive 
+ *              the results of the reduction operations.
+ * source
+ *              A symmetric array, of length nreduce elements, that 
+ *              contains one element for each separate reduction operation. 
+ *              The source argument must have the same data type as target.
+ *
+ * nreduce
+ *              The number of elements in the target and source arrays. 
+ *              nreduce must be of type integer. If you are using Fortran, 
+ *              it must be a default integer value.
+ *
+ * pWrk
+ *              A symmetric work array. The pWrk argument must have the same
+ *              data type as target.
+ *              In C/C++ or Fortran, this contains 
+ *              max(nreduce/2+1, SHMEM_REDUCE_MIN_WRKDATA_SIZE) elements.
+ *
+ * pSync
+ *              A symmetric work array. In C/C++, pSync is of type long and 
+ *              size SHMEM_REDUCE_SYNC_SIZE. In Fortran, pSync is of type 
+ *              integer and size SHMEM_REDUCE_SYNC_SIZE. If you are using
+ *              Fortran, it must be a default integer value. Every element 
+ *              of this array must be initialized with the value 
+ *              SHMEM_SYNC_VALUE before any of the PEs in the team enter 
+ *              the reduction routine.
+ *
+ * The values for arguments nreduce and team must be same in all PE team 
+ * members. The same target and source arrays, and the same pWrk and pSync 
+ * work arrays, must be passed to all PEs in the team. 
+ *
+ * Before any PE calls a reduction routine, you must ensure that the
+ * following conditions exist (synchronization via a barrier or some 
+ * other method is often needed to ensure this):
+ *
+ *    . The pWrk and pSync arrays on all PEs in the team are not
+ *      still in use from a prior call to a collective routine.
+ *
+ *    . The target array on all PEs in the team is ready to accept
+ *      the results of the reduction.
+ *
+ * Upon return from a reduction routine, the following is true for the
+ * local PE:
+ *
+ *    ·  The target array is updated.
+ *
+ * EXAMPLE DETAILS:
+ * The example program shows shmemx_team_int_and_to_all routine used to 
+ * perform collective reduction operation across all the PEs in the
+ * SHMEM_TEAM_WORLD team. SHMEM_TEAM_WORLD is a predefined team which
+ * includes all PEs
+ */
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+long pSync[SHMEM_REDUCE_SYNC_SIZE];
+
+#define N 3
+int dest[N];
+int source[N];
+
+#define MAX(a, b) ((a > b) ? a : b)
+#define PWRK_MAX_SIZE MAX(N/2+1, SHMEM_REDUCE_MIN_WRKDATA_SIZE)
+int pWrk[PWRK_MAX_SIZE];
+
+int main(int argc, char *argv[]) {
+    int i;
+    int me, npes;
+
+    shmem_init();
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++) {
+        pSync[i] = SHMEM_SYNC_VALUE;
+    }
+
+    for (i = 0; i < N; i++) {
+        source[i] = me;
+    }
+
+    shmem_barrier_all();
+    shmemx_team_int_and_to_all(SHMEM_TEAM_WORLD, dest, source, N, 
+                               pWrk, pSync);
+
+    for (i = 0; i < N; i++) {
+        printf("[PE:%d] dest[%d]=%d\n", me, i, dest[i]);
+    }
+
+    shmem_barrier_all();
+    shmem_finalize();
+    return 0;
+}

--- a/teams/usage/shmemx-team-max-to-all.c
+++ b/teams/usage/shmemx-team-max-to-all.c
@@ -1,0 +1,132 @@
+/*
+ * Example program to show the usage of shmemx_team_<datatype>_max_to_all
+ * routine
+ *
+ * SYNOPSIS:
+ * void shmemx_team_<datatype>_max_to_all(      shmem_team_t team,
+ *                                              <datatype>  *dest,
+ *                                              <datatype>  *source,
+ *                                              int          nreduce,
+ *                                              <datatype>  *pWrk,
+ *                                              long        *pSync  )
+ * 
+ * where <datatype> is one from short, int, long, float, double, longdouble, 
+ * and longlong
+ *
+ * DESCRIPTION:
+ * The shmemx_team_<datatype>_max_to_all is a collective routine which 
+ * compute one or more reductions across symmetric arrays on multiple 
+ * virtual PEs. A reduction performs an associative binary operation across
+ * a set of values. Each of these routines assumes that only PEs which are
+ * members of the team call the routine. If a PE not a member of the team
+ * calls a collective reduction routine, undefined behaviour results.
+ *
+ * The nreduce argument determines the number of separate reductions to
+ * perform. The source array on all PEs in the team provides one 
+ * element for each reduction. The results of the reductions are placed
+ * in the target array on all PEs in the team. The team is determined using 
+ * the team handle provided as input.
+ *
+ * The source and target arrays may be the same array, but they may not be 
+ * overlapping arrays.
+ *
+ * The shmemx_team_<datatype>_max_to_all supports the following options:
+ * team     
+ *              A valid PE team. A predefined team constant or any team 
+ *              created by a split team routine may be used
+ *
+ * dest
+ *              A symmetric array of length nreduce elements to receive 
+ *              the results of the reduction operations.
+ * source
+ *              A symmetric array, of length nreduce elements, that 
+ *              contains one element for each separate reduction operation. 
+ *              The source argument must have the same data type as target.
+ *
+ * nreduce
+ *              The number of elements in the target and source arrays. 
+ *              nreduce must be of type integer. If you are using Fortran, 
+ *              it must be a default integer value.
+ *
+ * pWrk
+ *              A symmetric work array. The pWrk argument must have the same
+ *              data type as target.
+ *              In C/C++ or Fortran, this contains 
+ *              max(nreduce/2+1, SHMEM_REDUCE_MIN_WRKDATA_SIZE) elements.
+ *
+ * pSync
+ *              A symmetric work array. In C/C++, pSync is of type long and 
+ *              size SHMEM_REDUCE_SYNC_SIZE. In Fortran, pSync is of type 
+ *              integer and size SHMEM_REDUCE_SYNC_SIZE. If you are using
+ *              Fortran, it must be a default integer value. Every element 
+ *              of this array must be initialized with the value 
+ *              SHMEM_SYNC_VALUE before any of the PEs in the team enter 
+ *              the reduction routine.
+ *
+ * The values for arguments nreduce and team must be same in all PE team 
+ * members. The same target and source arrays, and the same pWrk and pSync 
+ * work arrays, must be passed to all PEs in the team. 
+ *
+ * Before any PE calls a reduction routine, you must ensure that the
+ * following conditions exist (synchronization via a barrier or some 
+ * other method is often needed to ensure this):
+ *
+ *    . The pWrk and pSync arrays on all PEs in the team are not
+ *      still in use from a prior call to a collective routine.
+ *
+ *    . The target array on all PEs in the team is ready to accept
+ *      the results of the reduction.
+ *
+ * Upon return from a reduction routine, the following is true for the
+ * local PE:
+ *
+ *    ·  The target array is updated.
+ *
+ * EXAMPLE DETAILS:
+ * The example program shows shmemx_team_int_max_to_all routine used to 
+ * perform collective reduction operation across all the PEs in the
+ * SHMEM_TEAM_WORLD team. SHMEM_TEAM_WORLD is a predefined team which
+ * includes all PEs
+ */
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+long pSync[SHMEM_REDUCE_SYNC_SIZE];
+
+#define N 3
+int dest[N];
+int source[N];
+
+#define MAX(a, b) ((a > b) ? a : b)
+#define PWRK_MAX_SIZE MAX(N/2+1, SHMEM_REDUCE_MIN_WRKDATA_SIZE)
+int pWrk[PWRK_MAX_SIZE];
+
+int main(int argc, char *argv[]) {
+    int i;
+    int me, npes;
+
+    shmem_init();
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++) {
+        pSync[i] = SHMEM_SYNC_VALUE;
+    }
+
+    for (i = 0; i < N; i++) {
+        source[i] = me;
+    }
+
+    shmem_barrier_all();
+    shmemx_team_int_max_to_all(SHMEM_TEAM_WORLD, dest, source, N, 
+                               pWrk, pSync);
+
+    for (i = 0; i < N; i++) {
+        printf("[PE:%d] dest[%d]=%d\n", me, i, dest[i]);
+    }
+
+    shmem_barrier_all();
+    shmem_finalize();
+    return 0;
+}

--- a/teams/usage/shmemx-team-min-to-all.c
+++ b/teams/usage/shmemx-team-min-to-all.c
@@ -1,0 +1,132 @@
+/*
+ * Example program to show the usage of shmemx_team_<datatype>_min_to_all
+ * routine
+ *
+ * SYNOPSIS:
+ * void shmemx_team_<datatype>_min_to_all(      shmem_team_t team,
+ *                                              <datatype>  *dest,
+ *                                              <datatype>  *source,
+ *                                              int          nreduce,
+ *                                              <datatype>  *pWrk,
+ *                                              long        *pSync  )
+ * 
+ * where <datatype> is one from short, int, long, float, double, longdouble, 
+ * and longlong
+ *
+ * DESCRIPTION:
+ * The shmemx_team_<datatype>_min_to_all is a collective routine which 
+ * compute one or more reductions across symmetric arrays on multiple 
+ * virtual PEs. A reduction performs an associative binary operation across
+ * a set of values. Each of these routines assumes that only PEs which are
+ * members of the team call the routine. If a PE not a member of the team
+ * calls a collective reduction routine, undefined behaviour results.
+ *
+ * The nreduce argument determines the number of separate reductions to
+ * perform. The source array on all PEs in the team provides one 
+ * element for each reduction. The results of the reductions are placed
+ * in the target array on all PEs in the team. The team is determined using 
+ * the team handle provided as input.
+ *
+ * The source and target arrays may be the same array, but they may not be 
+ * overlapping arrays.
+ *
+ * The shmemx_team_<datatype>_min_to_all supports the following options:
+ * team     
+ *              A valid PE team. A predefined team constant or any team 
+ *              created by a split team routine may be used
+ *
+ * dest
+ *              A symmetric array of length nreduce elements to receive 
+ *              the results of the reduction operations.
+ * source
+ *              A symmetric array, of length nreduce elements, that 
+ *              contains one element for each separate reduction operation. 
+ *              The source argument must have the same data type as target.
+ *
+ * nreduce
+ *              The number of elements in the target and source arrays. 
+ *              nreduce must be of type integer. If you are using Fortran, 
+ *              it must be a default integer value.
+ *
+ * pWrk
+ *              A symmetric work array. The pWrk argument must have the same
+ *              data type as target.
+ *              In C/C++ or Fortran, this contains 
+ *              max(nreduce/2+1, SHMEM_REDUCE_MIN_WRKDATA_SIZE) elements.
+ *
+ * pSync
+ *              A symmetric work array. In C/C++, pSync is of type long and 
+ *              size SHMEM_REDUCE_SYNC_SIZE. In Fortran, pSync is of type 
+ *              integer and size SHMEM_REDUCE_SYNC_SIZE. If you are using
+ *              Fortran, it must be a default integer value. Every element 
+ *              of this array must be initialized with the value 
+ *              SHMEM_SYNC_VALUE before any of the PEs in the team enter 
+ *              the reduction routine.
+ *
+ * The values for arguments nreduce and team must be same in all PE team 
+ * members. The same target and source arrays, and the same pWrk and pSync 
+ * work arrays, must be passed to all PEs in the team. 
+ *
+ * Before any PE calls a reduction routine, you must ensure that the
+ * following conditions exist (synchronization via a barrier or some 
+ * other method is often needed to ensure this):
+ *
+ *    . The pWrk and pSync arrays on all PEs in the team are not
+ *      still in use from a prior call to a collective routine.
+ *
+ *    . The target array on all PEs in the team is ready to accept
+ *      the results of the reduction.
+ *
+ * Upon return from a reduction routine, the following is true for the
+ * local PE:
+ *
+ *    ·  The target array is updated.
+ *
+ * EXAMPLE DETAILS:
+ * The example program shows shmemx_team_int_min_to_all routine used to 
+ * perform collective reduction operation across all the PEs in the
+ * SHMEM_TEAM_WORLD team. SHMEM_TEAM_WORLD is a predefined team which
+ * includes all PEs
+ */
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+long pSync[SHMEM_REDUCE_SYNC_SIZE];
+
+#define N 3
+int dest[N];
+int source[N];
+
+#define max(a, b) ((a > b) ? a : b)
+#define PWRK_MAX_SIZE max(N/2+1, SHMEM_REDUCE_MIN_WRKDATA_SIZE)
+int pWrk[PWRK_MAX_SIZE];
+
+int main(int argc, char *argv[]) {
+    int i;
+    int me, npes;
+
+    shmem_init();
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++) {
+        pSync[i] = SHMEM_SYNC_VALUE;
+    }
+
+    for (i = 0; i < N; i++) {
+        source[i] = me;
+    }
+
+    shmem_barrier_all();
+    shmemx_team_int_min_to_all(SHMEM_TEAM_WORLD, dest, source, N, 
+                               pWrk, pSync);
+
+    for (i = 0; i < N; i++) {
+        printf("[PE:%d] dest[%d]=%d\n", me, i, dest[i]);
+    }
+
+    shmem_barrier_all();
+    shmem_finalize();
+    return 0;
+}

--- a/teams/usage/shmemx-team-or-to-all.c
+++ b/teams/usage/shmemx-team-or-to-all.c
@@ -1,9 +1,9 @@
 /*
- * Example program to show the usage of shmemx_team_<datatype>_xor_to_all
+ * Example program to show the usage of shmemx_team_<datatype>_or_to_all
  * routine
  *
  * SYNOPSIS:
- * void shmemx_team_<datatype>_xor_to_all(    shmem_team_t team,
+ * void shmemx_team_<datatype>_or_to_all(    shmem_team_t team,
  *                                              <datatype>  *dest,
  *                                              <datatype>  *source,
  *                                              int          nreduce,
@@ -13,7 +13,7 @@
  * where <datatype> is one from short, int, long, and longlong
  *
  * DESCRIPTION:
- * The shmemx_team_<datatype>_xor_to_all is a collective routine which 
+ * The shmemx_team_<datatype>_or_to_all is a collective routine which 
  * compute one or more reductions across symmetric arrays on multiple 
  * virtual PEs. A reduction performs an associative binary operation across
  * a set of values. Each of these routines asandes that only PEs which are
@@ -29,7 +29,7 @@
  * The source and target arrays may be the same array, but they may not be 
  * overlapping arrays.
  *
- * The shmemx_team_<datatype>_xor_to_all supports the following options:
+ * The shmemx_team_<datatype>_or_to_all supports the following options:
  * team     
  *              A valid PE team. A predefined team constant or any team 
  *              created by a split team routine may be used
@@ -82,7 +82,7 @@
  *    ·  The target array is updated.
  *
  * EXAMPLE DETAILS:
- * The example program shows shmemx_team_int_xor_to_all routine used to 
+ * The example program shows shmemx_team_int_or_to_all routine used to 
  * perform collective reduction operation across all the PEs in the
  * SHMEM_TEAM_WORLD team. SHMEM_TEAM_WORLD is a predefined team which
  * includes all PEs
@@ -114,11 +114,11 @@ int main(int argc, char *argv[]) {
     }
 
     for (i = 0; i < N; i++) {
-        source[i] = me % 2;
+        source[i] = (me+1)%4;
     }
 
     shmem_barrier_all();
-    shmemx_team_int_xor_to_all(SHMEM_TEAM_WORLD, dest, source, N, 
+    shmemx_team_int_or_to_all(SHMEM_TEAM_WORLD, dest, source, N, 
                                pWrk, pSync);
 
     for (i = 0; i < N; i++) {

--- a/teams/usage/shmemx-team-prod-to-all.c
+++ b/teams/usage/shmemx-team-prod-to-all.c
@@ -1,0 +1,132 @@
+/*
+ * Example program to show the usage of shmemx_team_<datatype>_prod_to_all
+ * routine
+ *
+ * SYNOPSIS:
+ * void shmemx_team_<datatype>_prod_to_all(    shmem_team_t team,
+ *                                              <datatype>  *dest,
+ *                                              <datatype>  *source,
+ *                                              int          nreduce,
+ *                                              <datatype>  *pWrk,
+ *                                              long        *pSync  )
+ * 
+ * where <datatype> is one from short, int, long, float, double, longdouble, 
+ * and longlong
+ *
+ * DESCRIPTION:
+ * The shmemx_team_<datatype>_prod_to_all is a collective routine which 
+ * compute one or more reductions across symmetric arrays on multiple 
+ * virtual PEs. A reduction performs an associative binary operation across
+ * a set of values. Each of these routines asprodes that only PEs which are
+ * members of the team call the routine. If a PE not a member of the team
+ * calls a collective reduction routine, undefined behaviour results.
+ *
+ * The nreduce argument determines the number of separate reductions to
+ * perform. The source array on all PEs in the team provides one 
+ * element for each reduction. The results of the reductions are placed
+ * in the target array on all PEs in the team. The team is determined using 
+ * the team handle provided as input.
+ *
+ * The source and target arrays may be the same array, but they may not be 
+ * overlapping arrays.
+ *
+ * The shmemx_team_<datatype>_prod_to_all supports the following options:
+ * team     
+ *              A valid PE team. A predefined team constant or any team 
+ *              created by a split team routine may be used
+ *
+ * dest
+ *              A symmetric array of length nreduce elements to receive 
+ *              the results of the reduction operations.
+ * source
+ *              A symmetric array, of length nreduce elements, that 
+ *              contains one element for each separate reduction operation. 
+ *              The source argument must have the same data type as target.
+ *
+ * nreduce
+ *              The number of elements in the target and source arrays. 
+ *              nreduce must be of type integer. If you are using Fortran, 
+ *              it must be a default integer value.
+ *
+ * pWrk
+ *              A symmetric work array. The pWrk argument must have the same
+ *              data type as target.
+ *              In C/C++ or Fortran, this contains 
+ *              max(nreduce/2+1, SHMEM_REDUCE_MIN_WRKDATA_SIZE) elements.
+ *
+ * pSync
+ *              A symmetric work array. In C/C++, pSync is of type long and 
+ *              size SHMEM_REDUCE_SYNC_SIZE. In Fortran, pSync is of type 
+ *              integer and size SHMEM_REDUCE_SYNC_SIZE. If you are using
+ *              Fortran, it must be a default integer value. Every element 
+ *              of this array must be initialized with the value 
+ *              SHMEM_SYNC_VALUE before any of the PEs in the team enter 
+ *              the reduction routine.
+ *
+ * The values for arguments nreduce and team must be same in all PE team 
+ * members. The same target and source arrays, and the same pWrk and pSync 
+ * work arrays, must be passed to all PEs in the team. 
+ *
+ * Before any PE calls a reduction routine, you must ensure that the
+ * following conditions exist (synchronization via a barrier or some 
+ * other method is often needed to ensure this):
+ *
+ *    . The pWrk and pSync arrays on all PEs in the team are not
+ *      still in use from a prior call to a collective routine.
+ *
+ *    . The target array on all PEs in the team is ready to accept
+ *      the results of the reduction.
+ *
+ * Upon return from a reduction routine, the following is true for the
+ * local PE:
+ *
+ *    ·  The target array is updated.
+ *
+ * EXAMPLE DETAILS:
+ * The example program shows shmemx_team_int_prod_to_all routine used to 
+ * perform collective reduction operation across all the PEs in the
+ * SHMEM_TEAM_WORLD team. SHMEM_TEAM_WORLD is a predefined team which
+ * includes all PEs
+ */
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+long pSync[SHMEM_REDUCE_SYNC_SIZE];
+
+#define N 3
+int dest[N];
+int source[N];
+
+#define MAX(a, b) ((a > b) ? a : b)
+#define PWRK_MAX_SIZE MAX(N/2+1, SHMEM_REDUCE_MIN_WRKDATA_SIZE)
+int pWrk[PWRK_MAX_SIZE];
+
+int main(int argc, char *argv[]) {
+    int i;
+    int me, npes;
+
+    shmem_init();
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++) {
+        pSync[i] = SHMEM_SYNC_VALUE;
+    }
+
+    for (i = 0; i < N; i++) {
+        source[i] = me;
+    }
+
+    shmem_barrier_all();
+    shmemx_team_int_prod_to_all(SHMEM_TEAM_WORLD, dest, source, N, 
+                               pWrk, pSync);
+
+    for (i = 0; i < N; i++) {
+        printf("[PE:%d] dest[%d]=%d\n", me, i, dest[i]);
+    }
+
+    shmem_barrier_all();
+    shmem_finalize();
+    return 0;
+}

--- a/teams/usage/shmemx-team-split-2d.c
+++ b/teams/usage/shmemx-team-split-2d.c
@@ -1,0 +1,100 @@
+/*
+ * Example Program to show the usage of shmemx_team_split_2d routine
+ * 
+ * SYNOPSIS:
+ * void shmemx_team_split_2d(  shmem_team_t parent_team,
+ *                             int xrange,
+ *                             int yrange,
+ *                             shmem_team_t *xaxis_team,
+ *                             shmem_team_t *yaxis_team )
+ *
+ * DESCRIPTION:
+ * The shmem_team_split_2d routine is a collective routine. It
+ * partitions an existing parent team into two subgroups, based on the
+ * two dimensional cartesian space defined by the tuple(xrange, yrange)
+ * describing the size of the each cartesian space in X and Y dimensions.
+ * Each subgroup contains all PEs that are in the same dimension, one 
+ * along the X-axis and other along Y-axis. Within each subgroup, the PEs
+ * are ranked based on position of the PE with respect to its dimension in 
+ * two dimensional cartesian space.
+ *
+ * Any valid PE team can be used as the parent team. This routine must
+ * be called by all PEs in the parent team. The value of the tuple must 
+ * be nonnegative. And, the size of the parent team should be greater than or
+ * equal to the size of the two dimensional cartesian space. None of the 
+ * parameters need to reside in symmetric memory.
+ *
+ * Error checking will be done to ensure a valid team handle is provided.
+ * All errors are considered fatal and will result in the job aborting
+ * with an informative error message.
+ * 
+ * The shmemx_team_split_2d routine supports the following options:
+ *
+ * parent_team
+ *          A valid PE team. A predefined team constant or any team created 
+ *          by a split team routine may be used
+ * 
+ * xrange
+ *          A nonnegative integer representing the number of elements in the
+ *          first dimension
+ *
+ * yrange
+ *          A nonnegative integer representing the number of elements in the
+ *          second dimension
+ *
+ * xaxis_team  
+ *          A new PE team handle representing a PE subset of all the
+ *          PEs that are in the same row in the X-axis.
+ *
+ * yaxis_team  
+ *          A new PE team handle representing a PE subset of all the
+ *          PEs that are in the same column in the Y-axis.
+ *
+ * EXAMPLE DETAILS:
+ * The example program shows shmemx_team_split_2d routine used to create two
+ * teams on all participating PEs forming a group of PEs which share the same 
+ * row on the xaxis as xaxis_team and PEs sharing the same column along yaxis 
+ * as yaxis_team. The size of the xaxis_team and yaxis_team are determined based 
+ * on the xrange and yrange values.
+ */
+#include <math.h>
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+int main(int argc, char *argv[]) {
+    int rank, npes;
+    int t_pe, t_size;
+    int xrange, yrange;
+    shmem_team_t xaxis_team;
+    shmem_team_t yaxis_team;
+
+    shmem_init();
+    rank = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    xrange = (npes != 1) ? floor(log(npes)/log(2)) : 1;
+    yrange = (npes != 1) ? floor(log(npes)/log(2)) : 1;
+    shmemx_team_split_2d(SHMEM_TEAM_WORLD, xrange, yrange, 
+                         &xaxis_team, &yaxis_team);
+
+    if (xaxis_team != SHMEM_TEAM_NULL) {
+        t_size = shmemx_team_npes(xaxis_team);
+        t_pe   = shmemx_team_mype(xaxis_team);
+
+        printf("Global PE %d has team_pe of %d out of %d in xaxis_team\n", 
+                rank, t_pe, t_size);
+    }
+
+    if (yaxis_team != SHMEM_TEAM_NULL) {
+        t_size = shmemx_team_npes(yaxis_team);
+        t_pe   = shmemx_team_mype(yaxis_team);
+
+        printf("Global PE %d has team_pe of %d out of %d in yaxis_team\n", 
+                rank, t_pe, t_size);
+    }
+
+    shmem_barrier_all();
+    shmem_finalize();
+    return 0;
+}

--- a/teams/usage/shmemx-team-split-2d.c
+++ b/teams/usage/shmemx-team-split-2d.c
@@ -79,16 +79,16 @@ int main(int argc, char *argv[]) {
                          &xaxis_team, &yaxis_team);
 
     if (xaxis_team != SHMEM_TEAM_NULL) {
-        t_size = shmemx_team_npes(xaxis_team);
-        t_pe   = shmemx_team_mype(xaxis_team);
+        t_size = shmemx_team_n_pes(xaxis_team);
+        t_pe   = shmemx_team_my_pe(xaxis_team);
 
         printf("Global PE %d has team_pe of %d out of %d in xaxis_team\n", 
                 rank, t_pe, t_size);
     }
 
     if (yaxis_team != SHMEM_TEAM_NULL) {
-        t_size = shmemx_team_npes(yaxis_team);
-        t_pe   = shmemx_team_mype(yaxis_team);
+        t_size = shmemx_team_n_pes(yaxis_team);
+        t_pe   = shmemx_team_my_pe(yaxis_team);
 
         printf("Global PE %d has team_pe of %d out of %d in yaxis_team\n", 
                 rank, t_pe, t_size);

--- a/teams/usage/shmemx-team-split-3d.c
+++ b/teams/usage/shmemx-team-split-3d.c
@@ -93,24 +93,24 @@ int main(int argc, char *argv[]) {
                          &zaxis_team);
 
     if (xaxis_team != SHMEM_TEAM_NULL) {
-        t_size = shmemx_team_npes(xaxis_team);
-        t_pe   = shmemx_team_mype(xaxis_team);
+        t_size = shmemx_team_n_pes(xaxis_team);
+        t_pe   = shmemx_team_my_pe(xaxis_team);
 
         printf("Global PE %d has team_pe of %d out of %d in xaxis_team\n", 
                 rank, t_pe, t_size);
     }
 
     if (yaxis_team != SHMEM_TEAM_NULL) {
-        t_size = shmemx_team_npes(yaxis_team);
-        t_pe   = shmemx_team_mype(yaxis_team);
+        t_size = shmemx_team_n_pes(yaxis_team);
+        t_pe   = shmemx_team_my_pe(yaxis_team);
 
         printf("Global PE %d has team_pe of %d out of %d in yaxis_team\n", 
                 rank, t_pe, t_size);
     }
 
     if (zaxis_team != SHMEM_TEAM_NULL) {
-        t_size = shmemx_team_npes(zaxis_team);
-        t_pe   = shmemx_team_mype(zaxis_team);
+        t_size = shmemx_team_n_pes(zaxis_team);
+        t_pe   = shmemx_team_my_pe(zaxis_team);
 
         printf("Global PE %d has team_pe of %d out of %d in zaxis_team\n", 
                 rank, t_pe, t_size);

--- a/teams/usage/shmemx-team-split-3d.c
+++ b/teams/usage/shmemx-team-split-3d.c
@@ -1,0 +1,124 @@
+/*
+ * Example Program to show the usage of shmemx_team_split_3d routine
+ * 
+ * SYNOPSIS:
+ * void shmemx_team_split_3d(  shmem_team_t parent_team,
+ *                             int xrange,
+ *                             int yrange,
+ *                             int zrange,
+ *                             shmem_team_t *xaxis_team,
+ *                             shmem_team_t *yaxis_team,
+ *                             shmem_team_t *zaxis_team )
+ *
+ * DESCRIPTION:
+ * The shmem_team_split_3d routine is a collective routine. It
+ * partitions an existing parent team into three subgroups, based on the
+ * three dimensional cartesian space defined by the triplet(xrange, yrange,
+ * and zrange) describing the size of the each cartesian space in X, Y, and 
+ * Z dimensions. Each subgroup contains all PEs that are in the same 
+ * dimension, along the X-axis, Y-axis and Z-axis. Within each subgroup, 
+ * the PEs are ranked based on position of the PE with respect to its 
+ * dimension in three dimensional cartesian space.
+ *
+ * Any valid PE team can be used as the parent team. This routine must
+ * be called by all PEs in the parent team. The value of the triplets must 
+ * be nonnegative. And, the size of the parent team should be greater than or
+ * equal to the size of the three dimensional cartesian space. None of the 
+ * parameters need to reside in symmetric memory.
+ *
+ * Error checking will be done to ensure a valid team handle is provided.
+ * All errors are considered fatal and will result in the job aborting
+ * with an informative error message.
+ * 
+ * The shmemx_team_split_3d routine supports the following options:
+ *
+ * parent_team
+ *          A valid PE team. A predefined team constant or any team created 
+ *          by a split team routine may be used
+ * 
+ * xrange
+ *          A nonnegative integer representing the number of elements in the
+ *          first dimension
+ *
+ * yrange
+ *          A nonnegative integer representing the number of elements in the
+ *          second dimension
+ *
+ * zrange
+ *          A nonnegative integer representing the number of elements in the
+ *          third dimension
+ *
+ * xaxis_team  
+ *          A new PE team handle representing a PE subset of all the
+ *          PEs that are in the same row in the X-axis.
+ *
+ * yaxis_team  
+ *          A new PE team handle representing a PE subset of all the
+ *          PEs that are in the same column in the Y-axis.
+ *
+ * zaxis_team  
+ *          A new PE team handle representing a PE subset of all the
+ *          PEs that are in the same position in in the Z-axis.
+ * 
+ * EXAMPLE DETAILS:
+ * The example program shows shmemx_team_split_3d routine used to create three
+ * teams on all participating PEs forming a group of PEs which share the same 
+ * row along the xaxis, column along the yaxis, and position along zaxis as 
+ * xaxis_team, yaxis_team, and zaxis_team respectively. The size of the 
+ * xaxis_team, yaxis_team and zaxis_team are determined based on the xrange, 
+ * yrange and zrange values respectively.
+ */
+#include <math.h>
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+int main(int argc, char *argv[]) {
+    int rank, npes;
+    int t_pe, t_size;
+    int xrange, yrange, zrange;
+    shmem_team_t xaxis_team;
+    shmem_team_t yaxis_team;
+    shmem_team_t zaxis_team;
+
+    shmem_init();
+    rank = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    xrange = (npes > 4) ? floor(log(npes)/log(2))-1 : 1;
+    yrange = (npes > 4) ? floor(log(npes)/log(2))-1 : 1;
+    zrange = (npes / (xrange*yrange));
+    shmemx_team_split_3d(SHMEM_TEAM_WORLD, xrange, yrange, 
+                         zrange, &xaxis_team, &yaxis_team,
+                         &zaxis_team);
+
+    if (xaxis_team != SHMEM_TEAM_NULL) {
+        t_size = shmemx_team_npes(xaxis_team);
+        t_pe   = shmemx_team_mype(xaxis_team);
+
+        printf("Global PE %d has team_pe of %d out of %d in xaxis_team\n", 
+                rank, t_pe, t_size);
+    }
+
+    if (yaxis_team != SHMEM_TEAM_NULL) {
+        t_size = shmemx_team_npes(yaxis_team);
+        t_pe   = shmemx_team_mype(yaxis_team);
+
+        printf("Global PE %d has team_pe of %d out of %d in yaxis_team\n", 
+                rank, t_pe, t_size);
+    }
+
+    if (zaxis_team != SHMEM_TEAM_NULL) {
+        t_size = shmemx_team_npes(zaxis_team);
+        t_pe   = shmemx_team_mype(zaxis_team);
+
+        printf("Global PE %d has team_pe of %d out of %d in zaxis_team\n", 
+                rank, t_pe, t_size);
+    }
+    
+    shmem_barrier_all();
+    shmem_finalize();
+    return 0;
+}
+
+

--- a/teams/usage/shmemx-team-split-color.c
+++ b/teams/usage/shmemx-team-split-color.c
@@ -7,6 +7,7 @@
  *                                  int key,
  *                                  shmem_team_t *new_team  )
  *
+ * DESCRIPTION:
  * The shmem_team_split_color routine is a collective routine. It
  * partitions an existing parent team into disjoint subgroups, one
  * for each value of color. Each subgroup contains all PEs of the same
@@ -76,8 +77,8 @@ int main(int argc, char *argv[]) {
     shmemx_team_split_color(SHMEM_TEAM_WORLD, color, key, &new_team);
     
     if (new_team != SHMEM_TEAM_NULL) {
-        t_size = shmemx_team_n_pes(new_team);
-        t_pe   = shmemx_team_my_pe(new_team);
+        t_size = shmemx_team_npes(new_team);
+        t_pe   = shmemx_team_mype(new_team);
 
         printf("Global PE %d has team_pe of %d out of %d\n", 
                 rank, t_pe, t_size);

--- a/teams/usage/shmemx-team-split-color.c
+++ b/teams/usage/shmemx-team-split-color.c
@@ -77,8 +77,8 @@ int main(int argc, char *argv[]) {
     shmemx_team_split_color(SHMEM_TEAM_WORLD, color, key, &new_team);
     
     if (new_team != SHMEM_TEAM_NULL) {
-        t_size = shmemx_team_npes(new_team);
-        t_pe   = shmemx_team_mype(new_team);
+        t_size = shmemx_team_n_pes(new_team);
+        t_pe   = shmemx_team_my_pe(new_team);
 
         printf("Global PE %d has team_pe of %d out of %d\n", 
                 rank, t_pe, t_size);

--- a/teams/usage/shmemx-team-split-color.c
+++ b/teams/usage/shmemx-team-split-color.c
@@ -76,8 +76,8 @@ int main(int argc, char *argv[]) {
     shmemx_team_split_color(SHMEM_TEAM_WORLD, color, key, &new_team);
     
     if (new_team != SHMEM_TEAM_NULL) {
-        t_size = shmem_team_n_pes(new_team);
-        t_pe   = shmem_team_my_pe(new_team);
+        t_size = shmemx_team_n_pes(new_team);
+        t_pe   = shmemx_team_my_pe(new_team);
 
         printf("Global PE %d has team_pe of %d out of %d\n", 
                 rank, t_pe, t_size);

--- a/teams/usage/shmemx-team-split-color.c
+++ b/teams/usage/shmemx-team-split-color.c
@@ -1,0 +1,89 @@
+/* 
+ * Example program to show the usage of shmemx_team_split_color routine
+ *
+ * SYNOPSIS:
+ * void shmemx_team_split_color(    shmem_team_t parent_team,
+ *                                  int color,
+ *                                  int key,
+ *                                  shmem_team_t *new_team  )
+ *
+ * The shmem_team_split_color routine is a collective routine. It
+ * partitions an existing parent team into disjoint subgroups, one
+ * for each value of color. Each subgroup contains all PEs of the same
+ * color. Within each subgroup, the PEs are ranked in the order defined
+ * by the value of the argument key, with ties broken according to their
+ * rank in the parent team. A new team is created for each subgroup and
+ * returned in the handle new_team. Each resulting new_team consists of
+ * a set of disjoint PEs.
+ *
+ * A PE may supply the color value SHMEM_COLOR_UNDEFINED, in which
+ * case a value of SHMEM_TEAM_NULL is returned for new_team, as this PE
+ * will not be a member of any new team. This is a collective call over
+ * all members of the parent team, but each PE is permitted to provide
+ * different values for color and key. This routine involves gathering
+ * the color and key data from all PEs in the parent team to determine
+ * the participants in the new team.
+ *
+ * Any valid PE team can be used as the parent team. This routine must
+ * be called by all PEs in the parent team. The value of color must be
+ * nonnegative or SHMEM_COLOR_UNDEFINED. None of the parameters need to
+ * reside in symmetric memory.
+ *
+ * Error checking will be done to ensure a valid team handle is provided.
+ * All errors are considered fatal and will result in the job aborting
+ * with an informative error message.
+ *
+ * The shmem_team_split_color routine supports the following options:
+ *
+ * parent_team
+ *        A valid PE team. A predefined team constant or any
+ *        team created by a split team routine may be used
+ *
+ * color     
+ *        A nonnegative integer representing the subgroup. PEs
+ *        with the same color are in the same new team. A value of
+ *        SHMEM_COLOR_UNDEFINED may be used to avoid team membership.
+ *
+ * key       
+ *        An integer controlling the PE number within the subgroup.
+ *
+ * new_team  
+ *        A new PE team handle representing a PE subset of all the
+ *        PEs that supplied the same color as the calling PE.
+ *
+ * EXAMPLE DETAILS:
+ * This example shows the shmem_team_split_color routine being used to
+ * create two disjoint PE subsets, one with all the even numbered PEs and
+ * one with the odd numbered PEs.
+ */
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+int main(int argc, char *argv[]) {
+    int rank, npes;
+    int color, key;
+    int t_pe, t_size;
+    shmem_team_t new_team;
+
+    shmem_init();
+    rank = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    /* split two teams from SHMEM_TEAM_WORLD into odd and even subsets */ 
+    color = rank % 2;
+    key   = rank;
+    shmemx_team_split_color(SHMEM_TEAM_WORLD, color, key, &new_team);
+    
+    if (new_team != SHMEM_TEAM_NULL) {
+        t_size = shmem_team_n_pes(new_team);
+        t_pe   = shmem_team_my_pe(new_team);
+
+        printf("Global PE %d has team_pe of %d out of %d\n", 
+                rank, t_pe, t_size);
+    }
+
+    shmem_barrier_all();
+    shmem_finalize();
+    return 0;
+}

--- a/teams/usage/shmemx-team-split-strided.c
+++ b/teams/usage/shmemx-team-split-strided.c
@@ -77,8 +77,8 @@ int main(int argc, char *argv[]) {
     shmemx_team_split_strided(SHMEM_TEAM_WORLD, 0, 2, npes/2, &new_team);
     
     if (new_team != SHMEM_TEAM_NULL) {
-        t_size = shmemx_team_npes(new_team);
-        t_pe   = shmemx_team_mype(new_team);
+        t_size = shmemx_team_n_pes(new_team);
+        t_pe   = shmemx_team_my_pe(new_team);
 
         printf("Global PE %d has team_pe of %d out of %d\n", 
                 rank, t_pe, t_size);

--- a/teams/usage/shmemx-team-split-strided.c
+++ b/teams/usage/shmemx-team-split-strided.c
@@ -57,9 +57,8 @@
  *        PEs, that is created from the PE triplet provided.
  *
  * EXAMPLE DETAILS:
- * The following example program creates a team based on the strided triplet
- * value. The strided triplet values create team based on all the PEs in the
- * SHMEM_TEAM_WORLD, which have even ranks.
+ * The example program creates a team based on the strided triplet
+ * value with all the even ranked PEs.
  */
 #include <stdio.h>
 #include <shmem.h>
@@ -74,17 +73,8 @@ int main(int argc, char *argv[]) {
     rank = shmem_my_pe();
     npes = shmem_n_pes();
 
-    if (npes <= 20) {
-        if (rank == 0) {
-            printf("Minumum 20 PEs are required for this example program\n");
-            shmem_global_exit(1);
-        }
-    }
-
-    shmem_barrier_all();
-
-    /* create a team from the first 10 even ranks in the SHMEM_TEAM_WORLD */
-    shmemx_team_split_strided(SHMEM_TEAM_WORLD, 0, 2, 10, &team1_from_team_world);
+    /* create a team of all even ranked PEs from SHMEM_TEAM_WORLD */
+    shmemx_team_split_strided(SHMEM_TEAM_WORLD, 0, 2, npes/2, &team1_from_team_world);
     
     if (team1_from_team_world != SHMEM_TEAM_NULL) {
         /* 

--- a/teams/usage/shmemx-team-split-strided.c
+++ b/teams/usage/shmemx-team-split-strided.c
@@ -1,0 +1,100 @@
+/*
+ * Example Program to show the usage of shmemx_team_split_strided routine
+ * 
+ * SYNOPSIS:
+ * void shmemx_team_split_strided(  shmem_team_t parent_team,
+ *                                  int PE_start,
+ *                                  int PE_stride,
+ *                                  int PE_size,
+ *                                  shmem_team_t *new_team  )
+ *
+ * DESCRIPTION:
+ * The shmemx_team_split_strided function is a collective routine. It
+ * Tpartitions the existing parent team into a new SHMEM team based on the
+ * PE triplet (PE_start, PE_stride, and PE_size) supplied to the
+ * function. It is important to note the use of the less restrictive
+ * PE_stride argument instead of logPE_stride. This method of creating a
+ * team with an arbitrary set of PEs is inherently restricted by its
+ * parameters, but allows for many additional use‐cases over using a
+ * logPE_stride parameter, and may provide an easier transition for
+ * existing SHMEM programs to create and use SHMEM teams. This function
+ * must be called by all processes contained in the SHMEM triplet
+ * specification. It may be called by additional PEs not included in the
+ * triplet specification, but for those processes a newteam value of
+ * SHMEM_TEAM_NULL is returned. All calling processes must provide the
+ * same values for the PE triplet. This function will return a newteam
+ * containing the PE subset specified by the triplet, and ordered by the
+ * existing global PE rank value. None of the parameters need to reside
+ * in symmetric memory.
+ *
+ * Error checking will be done to ensure a valid PE triplet is provided,
+ * and also to determine whether a valid team handle is provided for the
+ * parent_team.
+ *
+ * All errors are considered fatal and will result in the job aborting
+ * with an informative error message.
+ *
+ * The shmemx_team_split_strided function supports the following
+ * arguments:
+ *
+ * parent_team
+ *        A valid SHMEM team. The predefined teams SHMEM_TEAM_WORLD or
+ *        SHMEM_TEAM_NODE may be used, or any team created by the
+ *        users.
+ *
+ * PE_start  
+ *        The lowest virtual PE number of the parent_team of PEs.
+ *
+ * PE_stride 
+ *        The stride between consecutive virtual PE numbers in the
+ *        parent_team.
+ *     
+ * PE_size   
+ *        The number of PEs in the defined set.
+ *
+ * newteam   
+ *        A new SHMEM team handle, representing a PE subset of all the
+ *        PEs, that is created from the PE triplet provided.
+ *
+ * EXAMPLE DETAILS:
+ * The following example program creates a team based on the strided triplet
+ * value. The strided triplet values create team based on all the PEs in the
+ * SHMEM_TEAM_WORLD, which have even ranks.
+ */
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+int main(int argc, char *argv[]) {
+    int rank, npes;
+    shmem_team_t team1_from_team_world;
+    shmem_team_t team2_from_team1;
+
+    shmem_init();
+    rank = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    if (npes <= 20) {
+        if (rank == 0) {
+            printf("Minumum 20 PEs are required for this example program\n");
+            shmem_global_exit(1);
+        }
+    }
+
+    shmem_barrier_all();
+
+    /* create a team from the first 10 even ranks in the SHMEM_TEAM_WORLD */
+    shmemx_team_split_strided(SHMEM_TEAM_WORLD, 0, 2, 10, &team1_from_team_world);
+    
+    if (team1_from_team_world != SHMEM_TEAM_NULL) {
+        /* 
+         * only the PEs which are part of the new team can pass this check, all
+         * other PEs should have SHMEM_TEAM_NULL in the team handle
+         */
+        printf("PE: %d Hello from team1_from_team_world\n", rank);
+    }
+
+    shmem_barrier_all();
+    shmem_finalize();
+    return 0;
+}

--- a/teams/usage/shmemx-team-split-strided.c
+++ b/teams/usage/shmemx-team-split-strided.c
@@ -66,22 +66,22 @@
 
 int main(int argc, char *argv[]) {
     int rank, npes;
-    shmem_team_t team1_from_team_world;
-    shmem_team_t team2_from_team1;
+    int t_pe, t_size;
+    shmem_team_t new_team;
 
     shmem_init();
     rank = shmem_my_pe();
     npes = shmem_n_pes();
 
     /* create a team of all even ranked PEs from SHMEM_TEAM_WORLD */
-    shmemx_team_split_strided(SHMEM_TEAM_WORLD, 0, 2, npes/2, &team1_from_team_world);
+    shmemx_team_split_strided(SHMEM_TEAM_WORLD, 0, 2, npes/2, &new_team);
     
-    if (team1_from_team_world != SHMEM_TEAM_NULL) {
-        /* 
-         * only the PEs which are part of the new team can pass this check, all
-         * other PEs should have SHMEM_TEAM_NULL in the team handle
-         */
-        printf("PE: %d Hello from team1_from_team_world\n", rank);
+    if (new_team != SHMEM_TEAM_NULL) {
+        t_size = shmem_team_n_pes(new_team);
+        t_pe   = shmem_team_my_pe(new_team);
+
+        printf("Global PE %d has team_pe of %d out of %d\n", 
+                rank, t_pe, t_size);
     }
 
     shmem_barrier_all();

--- a/teams/usage/shmemx-team-split-strided.c
+++ b/teams/usage/shmemx-team-split-strided.c
@@ -77,8 +77,8 @@ int main(int argc, char *argv[]) {
     shmemx_team_split_strided(SHMEM_TEAM_WORLD, 0, 2, npes/2, &new_team);
     
     if (new_team != SHMEM_TEAM_NULL) {
-        t_size = shmemx_team_n_pes(new_team);
-        t_pe   = shmemx_team_my_pe(new_team);
+        t_size = shmemx_team_npes(new_team);
+        t_pe   = shmemx_team_mype(new_team);
 
         printf("Global PE %d has team_pe of %d out of %d\n", 
                 rank, t_pe, t_size);

--- a/teams/usage/shmemx-team-split-strided.c
+++ b/teams/usage/shmemx-team-split-strided.c
@@ -77,8 +77,8 @@ int main(int argc, char *argv[]) {
     shmemx_team_split_strided(SHMEM_TEAM_WORLD, 0, 2, npes/2, &new_team);
     
     if (new_team != SHMEM_TEAM_NULL) {
-        t_size = shmem_team_n_pes(new_team);
-        t_pe   = shmem_team_my_pe(new_team);
+        t_size = shmemx_team_n_pes(new_team);
+        t_pe   = shmemx_team_my_pe(new_team);
 
         printf("Global PE %d has team_pe of %d out of %d\n", 
                 rank, t_pe, t_size);

--- a/teams/usage/shmemx-team-sum-to-all.c
+++ b/teams/usage/shmemx-team-sum-to-all.c
@@ -1,0 +1,132 @@
+/*
+ * Example program to show the usage of shmemx_team_<datatype>_sum_to_all
+ * routine
+ *
+ * SYNOPSIS:
+ * void shmemx_team_<datatype>_sum_to_all(    shmem_team_t team,
+ *                                              <datatype>  *dest,
+ *                                              <datatype>  *source,
+ *                                              int          nreduce,
+ *                                              <datatype>  *pWrk,
+ *                                              long        *pSync  )
+ * 
+ * where <datatype> is one from short, int, long, float, double, longdouble, 
+ * and longlong
+ *
+ * DESCRIPTION:
+ * The shmemx_team_<datatype>_sum_to_all is a collective routine which 
+ * compute one or more reductions across symmetric arrays on multiple 
+ * virtual PEs. A reduction performs an associative binary operation across
+ * a set of values. Each of these routines assumes that only PEs which are
+ * members of the team call the routine. If a PE not a member of the team
+ * calls a collective reduction routine, undefined behaviour results.
+ *
+ * The nreduce argument determines the number of separate reductions to
+ * perform. The source array on all PEs in the team provides one 
+ * element for each reduction. The results of the reductions are placed
+ * in the target array on all PEs in the team. The team is determined using 
+ * the team handle provided as input.
+ *
+ * The source and target arrays may be the same array, but they may not be 
+ * overlapping arrays.
+ *
+ * The shmemx_team_<datatype>_sum_to_all supports the following options:
+ * team     
+ *              A valid PE team. A predefined team constant or any team 
+ *              created by a split team routine may be used
+ *
+ * dest
+ *              A symmetric array of length nreduce elements to receive 
+ *              the results of the reduction operations.
+ * source
+ *              A symmetric array, of length nreduce elements, that 
+ *              contains one element for each separate reduction operation. 
+ *              The source argument must have the same data type as target.
+ *
+ * nreduce
+ *              The number of elements in the target and source arrays. 
+ *              nreduce must be of type integer. If you are using Fortran, 
+ *              it must be a default integer value.
+ *
+ * pWrk
+ *              A symmetric work array. The pWrk argument must have the same
+ *              data type as target.
+ *              In C/C++ or Fortran, this contains 
+ *              max(nreduce/2+1, SHMEM_REDUCE_MIN_WRKDATA_SIZE) elements.
+ *
+ * pSync
+ *              A symmetric work array. In C/C++, pSync is of type long and 
+ *              size SHMEM_REDUCE_SYNC_SIZE. In Fortran, pSync is of type 
+ *              integer and size SHMEM_REDUCE_SYNC_SIZE. If you are using
+ *              Fortran, it must be a default integer value. Every element 
+ *              of this array must be initialized with the value 
+ *              SHMEM_SYNC_VALUE before any of the PEs in the team enter 
+ *              the reduction routine.
+ *
+ * The values for arguments nreduce and team must be same in all PE team 
+ * members. The same target and source arrays, and the same pWrk and pSync 
+ * work arrays, must be passed to all PEs in the team. 
+ *
+ * Before any PE calls a reduction routine, you must ensure that the
+ * following conditions exist (synchronization via a barrier or some 
+ * other method is often needed to ensure this):
+ *
+ *    . The pWrk and pSync arrays on all PEs in the team are not
+ *      still in use from a prior call to a collective routine.
+ *
+ *    . The target array on all PEs in the team is ready to accept
+ *      the results of the reduction.
+ *
+ * Upon return from a reduction routine, the following is true for the
+ * local PE:
+ *
+ *    ·  The target array is updated.
+ *
+ * EXAMPLE DETAILS:
+ * The example program shows shmemx_team_int_sum_to_all routine used to 
+ * perform collective reduction operation across all the PEs in the
+ * SHMEM_TEAM_WORLD team. SHMEM_TEAM_WORLD is a predefined team which
+ * includes all PEs
+ */
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+long pSync[SHMEM_REDUCE_SYNC_SIZE];
+
+#define N 3
+int dest[N];
+int source[N];
+
+#define MAX(a, b) ((a > b) ? a : b)
+#define PWRK_MAX_SIZE MAX(N/2+1, SHMEM_REDUCE_MIN_WRKDATA_SIZE)
+int pWrk[PWRK_MAX_SIZE];
+
+int main(int argc, char *argv[]) {
+    int i;
+    int me, npes;
+
+    shmem_init();
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++) {
+        pSync[i] = SHMEM_SYNC_VALUE;
+    }
+
+    for (i = 0; i < N; i++) {
+        source[i] = me;
+    }
+
+    shmem_barrier_all();
+    shmemx_team_int_sum_to_all(SHMEM_TEAM_WORLD, dest, source, N, 
+                               pWrk, pSync);
+
+    for (i = 0; i < N; i++) {
+        printf("[PE:%d] dest[%d]=%d\n", me, i, dest[i]);
+    }
+
+    shmem_barrier_all();
+    shmem_finalize();
+    return 0;
+}

--- a/teams/usage/shmemx-team-xor-to-all.c
+++ b/teams/usage/shmemx-team-xor-to-all.c
@@ -1,0 +1,131 @@
+/*
+ * Example program to show the usage of shmemx_team_<datatype>_xor_to_all
+ * routine
+ *
+ * SYNOPSIS:
+ * void shmemx_team_<datatype>_xor_to_all(    shmem_team_t team,
+ *                                              <datatype>  *dest,
+ *                                              <datatype>  *source,
+ *                                              int          nreduce,
+ *                                              <datatype>  *pWrk,
+ *                                              long        *pSync  )
+ * 
+ * where <datatype> is one from short, int, long, and longlong
+ *
+ * DESCRIPTION:
+ * The shmemx_team_<datatype>_xor_to_all is a collective routine which 
+ * compute one or more reductions across symmetric arrays on multiple 
+ * virtual PEs. A reduction performs an associative binary operation across
+ * a set of values. Each of these routines asandes that only PEs which are
+ * members of the team call the routine. If a PE not a member of the team
+ * calls a collective reduction routine, undefined behaviour results.
+ *
+ * The nreduce argument determines the number of separate reductions to
+ * perform. The source array on all PEs in the team provides one 
+ * element for each reduction. The results of the reductions are placed
+ * in the target array on all PEs in the team. The team is determined using 
+ * the team handle provided as input.
+ *
+ * The source and target arrays may be the same array, but they may not be 
+ * overlapping arrays.
+ *
+ * The shmemx_team_<datatype>_xor_to_all supports the following options:
+ * team     
+ *              A valid PE team. A predefined team constant or any team 
+ *              created by a split team routine may be used
+ *
+ * dest
+ *              A symmetric array of length nreduce elements to receive 
+ *              the results of the reduction operations.
+ * source
+ *              A symmetric array, of length nreduce elements, that 
+ *              contains one element for each separate reduction operation. 
+ *              The source argument must have the same data type as target.
+ *
+ * nreduce
+ *              The number of elements in the target and source arrays. 
+ *              nreduce must be of type integer. If you are using Fortran, 
+ *              it must be a default integer value.
+ *
+ * pWrk
+ *              A symmetric work array. The pWrk argument must have the same
+ *              data type as target.
+ *              In C/C++ or Fortran, this contains 
+ *              max(nreduce/2+1, SHMEM_REDUCE_MIN_WRKDATA_SIZE) elements.
+ *
+ * pSync
+ *              A symmetric work array. In C/C++, pSync is of type long and 
+ *              size SHMEM_REDUCE_SYNC_SIZE. In Fortran, pSync is of type 
+ *              integer and size SHMEM_REDUCE_SYNC_SIZE. If you are using
+ *              Fortran, it must be a default integer value. Every element 
+ *              of this array must be initialized with the value 
+ *              SHMEM_SYNC_VALUE before any of the PEs in the team enter 
+ *              the reduction routine.
+ *
+ * The values for arguments nreduce and team must be same in all PE team 
+ * members. The same target and source arrays, and the same pWrk and pSync 
+ * work arrays, must be passed to all PEs in the team. 
+ *
+ * Before any PE calls a reduction routine, you must ensure that the
+ * following conditions exist (synchronization via a barrier or some 
+ * other method is often needed to ensure this):
+ *
+ *    . The pWrk and pSync arrays on all PEs in the team are not
+ *      still in use from a prior call to a collective routine.
+ *
+ *    . The target array on all PEs in the team is ready to accept
+ *      the results of the reduction.
+ *
+ * Upon return from a reduction routine, the following is true for the
+ * local PE:
+ *
+ *    ·  The target array is updated.
+ *
+ * EXAMPLE DETAILS:
+ * The example program shows shmemx_team_int_xor_to_all routine used to 
+ * perform collective reduction operation across all the PEs in the
+ * SHMEM_TEAM_WORLD team. SHMEM_TEAM_WORLD is a predefined team which
+ * includes all PEs
+ */
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+long pSync[SHMEM_REDUCE_SYNC_SIZE];
+
+#define N 3
+int dest[N];
+int source[N];
+
+#define MAX(a, b) ((a > b) ? a : b)
+#define PWRK_MAX_SIZE MAX(N/2+1, SHMEM_REDUCE_MIN_WRKDATA_SIZE)
+int pWrk[PWRK_MAX_SIZE];
+
+int main(int argc, char *argv[]) {
+    int i;
+    int me, npes;
+
+    shmem_init();
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++) {
+        pSync[i] = SHMEM_SYNC_VALUE;
+    }
+
+    for (i = 0; i < N; i++) {
+        source[i] = me;
+    }
+
+    shmem_barrier_all();
+    shmemx_team_int_xor_to_all(SHMEM_TEAM_WORLD, dest, source, N, 
+                               pWrk, pSync);
+
+    for (i = 0; i < N; i++) {
+        printf("[PE:%d] dest[%d]=%d\n", me, i, dest[i]);
+    }
+
+    shmem_barrier_all();
+    shmem_finalize();
+    return 0;
+}


### PR DESCRIPTION
Example usage codes has been added for the following new 
shmemx_teams routines:
- shmemx_team_split_strided(..)
- shmemx_team_split_color(..)
- shmemx_team_split_2d(..) 
- shmemx-team-sum-to-all int datatype variant
- shmemx-team-max-to-all int datatype variant
- shmemx-team-min-to-all int datatype variant
- shmemx-team-prod-to-all int datatype variant
- shmemx-team-and-to-all int datatype variant
- shmemx-team-xor-to-all int datatype variant
- shmemx-team-or-to-all int datatype variant
